### PR TITLE
Updating some of it.

### DIFF
--- a/src/commands/Media/steal.ts
+++ b/src/commands/Media/steal.ts
@@ -21,7 +21,7 @@ export default class Command extends BaseCommand {
 			command: "steal",
 			aliases: ["take"],
 			description: "Will format the given sticker.",
-			category: "utils",
+			category: "media",
 			usage: `${client.config.prefix}steal[tag_sticker]|pack|author`,
 			baseXp: 30,
 		});

--- a/src/commands/Media/steal.ts
+++ b/src/commands/Media/steal.ts
@@ -1,41 +1,111 @@
-import { MessageType, Mimetype } from '@adiwajshing/baileys'
-import { Sticker, Categories, StickerTypes } from 'wa-sticker-formatter'
-import MessageHandler from '../../Handlers/MessageHandler'
-import BaseCommand from '../../lib/BaseCommand'
-import WAClient from '../../lib/WAClient'
-import { IParsedArgs, ISimplifiedMessage } from '../../typings'
-import fs from 'fs';
-import { tmpdir } from 'os';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { MessageType, Mimetype } from "@adiwajshing/baileys";
+import { Sticker, Categories, StickerTypes } from "wa-sticker-formatter";
+import MessageHandler from "../../Handlers/MessageHandler";
+import BaseCommand from "../../lib/BaseCommand";
+import WAClient from "../../lib/WAClient";
+import { IParsedArgs, ISimplifiedMessage } from "../../typings";
+import fs from "fs";
+import { tmpdir } from "os";
+import { exec } from "child_process";
+import { promisify } from "util";
 export default class Command extends BaseCommand {
-    exe() {
-        throw new Error('Method not implemented.')
-    }
-    constructor(client: WAClient, handler: MessageHandler) {
-        super(client, handler, {
-            command: 'steal',
-            aliases: ['st'],
-            description: 'steals the sticker for you',
-            category: 'media',
-            usage: `${client.config.prefix}sticker [(as caption | tag)[sticker]]`,
-            baseXp: 30
-        })
-    }
-    
-    run = async (M: ISimplifiedMessage, parsedArgs: IParsedArgs): Promise<void> => {
-        let buffer
- const pack = parsedArgs.joined.split('|');
- if (M.quoted?.message?.message?.stickerMessage) buffer = await this.client.downloadMediaMessage(M.quoted.message)
-        if (!buffer) return void M.reply(`You didn't provide any sticker to convert`)
-        const filename = `${tmpdir()}/${Math.random().toString(36)}`
-        const sticker:any = await  new Sticker(buffer, {
-            pack: pack[1] || '👾 For You ', 
-            author: pack[2] || 'By Monarch+Kaoi 👾', 
-            quality: 50 
-        }).build();
-          fs.writeFileSync(`${filename}.webp`,sticker);
-        const stickerbuffer =  fs.readFileSync(`${filename}.webp`)
-                 await M.reply(stickerbuffer, MessageType.sticker, Mimetype.webp)
-    }
+	exe() {
+		throw new Error("Method not implemented.");
+	}
+	constructor(client: WAClient, handler: MessageHandler) {
+		super(client, handler, {
+			command: "steal",
+			aliases: ["st", "take"],
+			description: "Will format the given sticker.",
+			category: "media",
+			usage: `${client.config.prefix}steal[tag_sticker]|pack|author`,
+			baseXp: 30,
+		});
+	}
+
+	run = async (
+		M: ISimplifiedMessage,
+		parsedArgs: IParsedArgs
+	): Promise<void> => {
+		let buffer;
+		if (M.quoted?.message?.message?.stickerMessage)
+			buffer = await this.client.downloadMediaMessage(M.quoted.message);
+		if (!buffer)
+			return void M.reply(`Please provide a sticker to format.`);
+		const filename = `${tmpdir()}/${Math.random().toString(36)}`;
+		const getQuality = (): number => {
+			const qualityFlag = parsedArgs.joined.match(/--(\d+)/g) || "";
+			return qualityFlag.length
+				? parseInt(qualityFlag[0].split("--")[1], 10)
+				: parsedArgs.flags.includes("--broke")
+				? 1
+				: parsedArgs.flags.includes("--low")
+				? 10
+				: parsedArgs.flags.includes("--high")
+				? 100
+				: 50;
+		};
+
+		let quality = getQuality();
+		if (quality > 100 || quality < 1) quality = 50;
+
+		parsedArgs.flags.forEach(
+			(flag) => (parsedArgs.joined = parsedArgs.joined.replace(flag, ""))
+		);
+		const getOptions = () => {
+			const pack = parsedArgs.joined.split("|");
+            if (pack[1] == '') 
+			return void M.reply(`Please provide the new name and author of this sticker.\nExample: ${this.client.config.prefix}steal | By | Kaoi`)
+			const categories = (() => {
+				const categories = parsedArgs.flags.reduce((categories, flag) => {
+					switch (flag) {
+						case "--angry":
+							categories.push("💢");
+							break;
+						case "--love":
+							categories.push("💕");
+							break;
+						case "--sad":
+							categories.push("😭");
+							break;
+						case "--happy":
+							categories.push("😂");
+							break;
+						case "--greet":
+							categories.push("👋");
+							break;
+						case "--celebrate":
+							categories.push("🎊");
+							break;
+					}
+					return categories;
+				}, new Array<Categories>());
+				categories.length = 2;
+				if (!categories[0]) categories.push("❤", "🌹");
+				return categories;
+			})();
+			return {
+				categories,
+				pack: pack[1] || "👾 For You  ",
+				author: pack[2] || M.sender.jid,
+				quality,
+				type: StickerTypes[
+					parsedArgs.flags.includes("--crop") ||
+					parsedArgs.flags.includes("--c")
+						? "CROPPED"
+						: parsedArgs.flags.includes("--stretch") ||
+						  parsedArgs.flags.includes("--s")
+						? "DEFAULT"
+						: "FULL"
+				],
+			};
+		};
+		parsedArgs.flags.forEach(
+			(flag) => (parsedArgs.joined = parsedArgs.joined.replace(flag, ""))
+		);
+		const sticker: any = await new Sticker(buffer, getOptions()).build();
+		fs.writeFileSync(`${filename}.webp`, sticker);
+		const stickerbuffer = fs.readFileSync(`${filename}.webp`);
+		await M.reply(stickerbuffer, MessageType.sticker, Mimetype.webp);
+	};
 }

--- a/src/commands/Media/steal.ts
+++ b/src/commands/Media/steal.ts
@@ -1,3 +1,7 @@
+/*eslint-disable @typescript-eslint/no-explicit-any */
+/*eslint-disable @typescript-eslint/no-unused-vars */
+/*eslint-disable @typescript-eslint/explicit-module-boundary-types*/
+
 import { MessageType, Mimetype } from "@adiwajshing/baileys";
 import { Sticker, Categories, StickerTypes } from "wa-sticker-formatter";
 import MessageHandler from "../../Handlers/MessageHandler";
@@ -15,9 +19,9 @@ export default class Command extends BaseCommand {
 	constructor(client: WAClient, handler: MessageHandler) {
 		super(client, handler, {
 			command: "steal",
-			aliases: ["st", "take"],
+			aliases: ["take"],
 			description: "Will format the given sticker.",
-			category: "media",
+			category: "utils",
 			usage: `${client.config.prefix}steal[tag_sticker]|pack|author`,
 			baseXp: 30,
 		});
@@ -31,81 +35,83 @@ export default class Command extends BaseCommand {
 		if (M.quoted?.message?.message?.stickerMessage)
 			buffer = await this.client.downloadMediaMessage(M.quoted.message);
 		if (!buffer)
-			return void M.reply(`Please provide a sticker to format.`);
-		const filename = `${tmpdir()}/${Math.random().toString(36)}`;
-		const getQuality = (): number => {
-			const qualityFlag = parsedArgs.joined.match(/--(\d+)/g) || "";
-			return qualityFlag.length
-				? parseInt(qualityFlag[0].split("--")[1], 10)
-				: parsedArgs.flags.includes("--broke")
-				? 1
-				: parsedArgs.flags.includes("--low")
-				? 10
-				: parsedArgs.flags.includes("--high")
-				? 100
-				: 50;
-		};
-
-		let quality = getQuality();
-		if (quality > 100 || quality < 1) quality = 50;
-
-		parsedArgs.flags.forEach(
-			(flag) => (parsedArgs.joined = parsedArgs.joined.replace(flag, ""))
-		);
-		const getOptions = () => {
+			return void M.reply(`Provide a sticker to format, Baka!`);
 			const pack = parsedArgs.joined.split("|");
-            if (pack[1] == '') 
-			return void M.reply(`Please provide the new name and author of this sticker.\nExample: ${this.client.config.prefix}steal | By | Kaoi`)
-			const categories = (() => {
-				const categories = parsedArgs.flags.reduce((categories, flag) => {
-					switch (flag) {
-						case "--angry":
-							categories.push("💢");
-							break;
-						case "--love":
-							categories.push("💕");
-							break;
-						case "--sad":
-							categories.push("😭");
-							break;
-						case "--happy":
-							categories.push("😂");
-							break;
-						case "--greet":
-							categories.push("👋");
-							break;
-						case "--celebrate":
-							categories.push("🎊");
-							break;
-					}
-					return categories;
-				}, new Array<Categories>());
-				categories.length = 2;
-				if (!categories[0]) categories.push("❤", "🌹");
-				return categories;
-			})();
-			return {
-				categories,
-				pack: pack[1],
-				author: pack[2] || M.sender.username,
-				quality,
-				type: StickerTypes[
-					parsedArgs.flags.includes("--crop") ||
-					parsedArgs.flags.includes("--c")
-						? "CROPPED"
-						: parsedArgs.flags.includes("--stretch") ||
-						  parsedArgs.flags.includes("--s")
-						? "DEFAULT"
-						: "FULL"
-				],
+			if (!pack[1])
+				return void M.reply(
+					`Please provide the new name and author of the sticker.\nExample: ${this.client.config.prefix}steal | By | Kaoi`
+				);
+			const filename = `${tmpdir()}/${Math.random().toString(36)}`;
+			const getQuality = (): number => {
+				const qualityFlag = parsedArgs.joined.match(/--(\d+)/g) || "";
+				return qualityFlag.length
+					? parseInt(qualityFlag[0].split("--")[1], 10)
+					: parsedArgs.flags.includes("--broke")
+					? 1
+					: parsedArgs.flags.includes("--low")
+					? 10
+					: parsedArgs.flags.includes("--high")
+					? 100
+					: 50;
 			};
-		};
-		parsedArgs.flags.forEach(
-			(flag) => (parsedArgs.joined = parsedArgs.joined.replace(flag, ""))
-		);
-		const sticker: any = await new Sticker(buffer, getOptions()).build();
-		fs.writeFileSync(`${filename}.webp`, sticker);
-		const stickerbuffer = fs.readFileSync(`${filename}.webp`);
+
+			let quality = getQuality();
+			if (quality > 100 || quality < 1) quality = 50;
+
+			parsedArgs.flags.forEach(
+				(flag) => (parsedArgs.joined = parsedArgs.joined.replace(flag, ""))
+			);
+			const getOptions = () => {
+				const categories = (() => {
+					const categories = parsedArgs.flags.reduce((categories, flag) => {
+						switch (flag) {
+							case "--angry":
+								categories.push("💢");
+								break;
+							case "--love":
+								categories.push("💕");
+								break;
+							case "--sad":
+								categories.push("😭");
+								break;
+							case "--happy":
+								categories.push("😂");
+								break;
+							case "--greet":
+								categories.push("👋");
+								break;
+							case "--celebrate":
+								categories.push("🎊");
+								break;
+						}
+						return categories;
+					}, new Array<Categories>());
+					categories.length = 2;
+					if (!categories[0]) categories.push("❤", "🌹");
+					return categories;
+				})();
+				return {
+					categories,
+					pack: pack[1],
+					author: pack[2] || `${M.sender.username}`,
+					quality,
+					type: StickerTypes[
+						parsedArgs.flags.includes("--crop") ||
+						parsedArgs.flags.includes("--c")
+							? "CROPPED"
+							: parsedArgs.flags.includes("--stretch") ||
+							  parsedArgs.flags.includes("--s")
+							? "DEFAULT"
+							: "FULL"
+					],
+				};
+			};
+			parsedArgs.flags.forEach(
+				(flag) => (parsedArgs.joined = parsedArgs.joined.replace(flag, ""))
+			);
+			const sticker: any = await new Sticker(buffer, getOptions()).build();
+			fs.writeFileSync(`${filename}.webp`, sticker);
+			const stickerbuffer = fs.readFileSync(`${filename}.webp`);
 		await M.reply(stickerbuffer, MessageType.sticker, Mimetype.webp);
 	};
 }

--- a/src/commands/Media/steal.ts
+++ b/src/commands/Media/steal.ts
@@ -86,8 +86,8 @@ export default class Command extends BaseCommand {
 			})();
 			return {
 				categories,
-				pack: pack[1] || "👾 For You  ",
-				author: pack[2] || M.sender.jid,
+				pack: pack[1],
+				author: pack[2] || M.sender.username,
 				quality,
 				type: StickerTypes[
 					parsedArgs.flags.includes("--crop") ||


### PR DESCRIPTION
As some of you have tested this command. You may also know that the previous one doesn't works for animated stickers when the gif/video is of high quality, so in this one I have added options for the `Sticker Types` and `Quality` (copied from the `Sticker` command) so that it won't have any problem in formatting animated stickers. I have also fixed some typos. And as the command name indicates this command is used for stealing stickers, but when the sender doesn't gives the new author of the sticker, the author will be `Kaoi` , so I think this is not a good idea so I have changed it to the sender username. And I have also made the bot to send an example for this command when the user doesn't gives us the new pack of the sticker.